### PR TITLE
Corrected code snippet on website. Yield the person u, not the predicate p.

### DIFF
--- a/docs/content/index.fsx
+++ b/docs/content/index.fsx
@@ -99,7 +99,7 @@ let satisfies  =
  <@ fun p -> query { 
     for u in db.People do
         if p u.Age then 
-            yield p
+            yield u
    } @>
 
 (** We can now use this function, for example, to find all people with age at least 20 and less than 30: *)


### PR DESCRIPTION
Just noticed a possible error on the website. Code sample seems to be yielding a predicate rather than the thing in the database.
